### PR TITLE
Only truncate if table exists

### DIFF
--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -252,7 +252,14 @@ DestinationSdkImpl::Truncate(::grpc::ServerContext *context,
     std::unique_ptr<duckdb::Connection> con =
         get_connection(request->configuration(), db_name);
 
-    truncate_table(*con, table_name);
+    if (table_exists(*con, table_name)) {
+      truncate_table(*con, table_name);
+    } else {
+      mdlog::warning("Table <" + request->table_name() +
+                     "> not found in schema <" + request->schema_name() +
+                     ">; not truncated");
+    }
+
   } catch (const std::exception &e) {
     mdlog::severe("Truncate endpoint failed for schema <" +
                   request->schema_name() + ">, table <" +

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -443,3 +443,24 @@ TEST_CASE("WriteBatch", "[integration][current]") {
     REQUIRE(res->RowCount() == 0);
   }
 }
+
+TEST_CASE("Truncate nonexistent table should succeed", "[integration]") {
+  DestinationSdkImpl service;
+
+  const std::string bad_table_name =
+      "nonexistent" + std::to_string(Catch::rngSeed());
+
+  auto token = std::getenv("motherduck_token");
+  REQUIRE(token);
+
+  ::fivetran_sdk::TruncateRequest request;
+  (*request.mutable_configuration())["motherduck_token"] = token;
+  (*request.mutable_configuration())["motherduck_database"] = "fivetran_test";
+  request.set_schema_name("some_schema");
+  request.set_table_name(bad_table_name);
+  ::fivetran_sdk::TruncateResponse response;
+  auto status = service.Truncate(nullptr, &request, &response);
+
+  INFO(status.error_message());
+  REQUIRE(status.ok());
+}


### PR DESCRIPTION
Per [dev guide](https://github.com/fivetran/fivetran_sdk/blob/main/development-guide.md#truncate), truncate should succeed if the requested table does not exist.