### PR TITLE
feat: Set up config check for connection validity

### DIFF
--- a/includes/motherduck_destination_server.hpp
+++ b/includes/motherduck_destination_server.hpp
@@ -6,6 +6,9 @@ static constexpr const char *const MD_PROP_DATABASE = "motherduck_database";
 
 static constexpr const char *const MD_PROP_TOKEN = "motherduck_token";
 
+static constexpr const char *const CONFIG_TEST_NAME_AUTHENTICATE =
+    "test_authentication";
+
 class DestinationSdkImpl final : public fivetran_sdk::Destination::Service {
 public:
   DestinationSdkImpl() = default;

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -363,9 +363,19 @@ DestinationSdkImpl::Test(::grpc::ServerContext *context,
                          const ::fivetran_sdk::TestRequest *request,
                          ::fivetran_sdk::TestResponse *response) {
 
+  std::string db_name;
   try {
-    std::string db_name =
-        find_property(request->configuration(), MD_PROP_DATABASE);
+    db_name = find_property(request->configuration(), MD_PROP_DATABASE);
+  } catch (const std::exception &e) {
+    auto msg = "Test endpoint failed; could not retrieve database name: " +
+               std::string(e.what());
+    mdlog::severe(msg);
+    response->set_success(false);
+    response->set_failure(msg);
+    return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT, e.what());
+  }
+
+  try {
     std::unique_ptr<duckdb::Connection> con =
         get_connection(request->configuration(), db_name);
 
@@ -373,16 +383,20 @@ DestinationSdkImpl::Test(::grpc::ServerContext *context,
       check_connection(*con);
       response->set_success(true);
     } else {
-      auto const err = "Unknown test requested: <" + request->name() + ">";
-      mdlog::severe(err);
-      return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT, err);
+      auto const msg = "Unknown test requested: <" + request->name() + ">";
+      mdlog::severe(msg);
+      response->set_success(false);
+      response->set_failure(msg);
+      return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT, msg);
     }
     response->set_success(true);
   } catch (const std::exception &e) {
-    mdlog::severe("Test endpoint failed: " + std::string(e.what()));
+    auto msg = "Authentication test for database <" + db_name +
+               "> failed: " + std::string(e.what());
     response->set_success(false);
-    response->set_failure(e.what());
-    return ::grpc::Status(::grpc::StatusCode::INTERNAL, e.what());
+    response->set_failure(msg);
+    // grpc call succeeded; the response reflects config test failure
+    return ::grpc::Status(::grpc::StatusCode::OK, msg);
   }
 
   return ::grpc::Status(::grpc::StatusCode::OK, "");

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -191,8 +191,14 @@ TEST_CASE("Test fails when token is missing", "[integration]") {
 
   auto status = service.Test(nullptr, &request, &response);
 
-  REQUIRE(!status.ok());
-  REQUIRE(status.error_message() == "Missing property motherduck_token");
+  REQUIRE(status.ok());
+  REQUIRE(!response.success());
+  REQUIRE(status.error_message() ==
+          "Authentication test for database <fivetran_test> failed: Missing "
+          "property motherduck_token");
+  REQUIRE(response.failure() ==
+          "Authentication test for database <fivetran_test> failed: Missing "
+          "property motherduck_token");
 }
 
 TEST_CASE("Test endpoint fails when token is bad", "[integration]") {
@@ -206,7 +212,10 @@ TEST_CASE("Test endpoint fails when token is bad", "[integration]") {
 
   auto status = service.Test(nullptr, &request, &response);
 
-  REQUIRE(!status.ok());
+  REQUIRE(status.ok());
+  REQUIRE(!response.success());
+  CHECK_THAT(status.error_message(),
+             Catch::Matchers::ContainsSubstring("UNAUTHENTICATED"));
   CHECK_THAT(status.error_message(),
              Catch::Matchers::ContainsSubstring("UNAUTHENTICATED"));
 }

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -22,6 +22,9 @@ TEST_CASE("ConfigurationForm", "[integration]") {
   REQUIRE(response->fields_size() == 2);
   REQUIRE(response->fields(0).name() == "motherduck_token");
   REQUIRE(response->fields(1).name() == "motherduck_database");
+  REQUIRE(response->tests_size() == 1);
+  REQUIRE(response->tests(0).name() == CONFIG_TEST_NAME_AUTHENTICATE);
+  REQUIRE(response->tests(0).label() == "Test Authentication");
 }
 
 TEST_CASE("DescribeTable fails when database missing", "[integration]") {
@@ -206,6 +209,25 @@ TEST_CASE("Test endpoint fails when token is bad", "[integration]") {
   REQUIRE(!status.ok());
   CHECK_THAT(status.error_message(),
              Catch::Matchers::ContainsSubstring("UNAUTHENTICATED"));
+}
+
+TEST_CASE("Test endpoint succeeds when everything is in order",
+          "[integration]") {
+  DestinationSdkImpl service;
+
+  ::fivetran_sdk::TestRequest request;
+  auto token = std::getenv("motherduck_token");
+  REQUIRE(token);
+  request.set_name(CONFIG_TEST_NAME_AUTHENTICATE);
+  (*request.mutable_configuration())["motherduck_database"] = "fivetran_test";
+  (*request.mutable_configuration())["motherduck_token"] = token;
+
+  ::fivetran_sdk::TestResponse response;
+
+  auto status = service.Test(nullptr, &request, &response);
+
+  INFO(status.error_message());
+  REQUIRE(status.ok());
 }
 
 template <typename T>


### PR DESCRIPTION
Fivetran framework expects a list of connection tests to be returned from the `ConfigurationForm` endpoint. It will then call the `Test` endpoint in order for each of the tests specified. 

Given that the token is already a required property on the Fivetran side, for the MotherDuck destination there is only one useful check -- "can the user authenticate?". The check already existed, but it was not making use of the `TestRequest.name()` field. 

I thought about making an unknown test name log a warning and succeed, but this will just hide potential integration problems, so I ended up making it an error instead.

Fixes #5 

For reference, here is an example of configuration tests for a Github source:
![Screenshot from 2024-02-12 08-57-22](https://github.com/MotherDuck-Open-Source/motherduck-fivetran-connector/assets/41136058/c1fd0864-3574-494c-8089-ccbf0f176f6c)
