### PR TITLE
Fix truncate behavior

### DIFF
--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -48,7 +48,7 @@ void update_values(duckdb::Connection &con, const table_def &table,
 
 void truncate_table(duckdb::Connection &con, const table_def &table,
                     const std::string &synced_column,
-                    std::chrono::nanoseconds &combined_duration,
+                    std::chrono::nanoseconds &cutoff_ns,
                     const std::string &deleted_column);
 
 void delete_rows(duckdb::Connection &con, const table_def &table,

--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -46,7 +46,9 @@ void update_values(duckdb::Connection &con, const table_def &table,
                    std::vector<const column_def *> &columns_regular,
                    const std::string &unmodified_string);
 
-void truncate_table(duckdb::Connection &con, const table_def &table);
+void truncate_table(duckdb::Connection &con, const table_def &table,
+                    const std::string synced_column,
+                    std::chrono::nanoseconds combined_duration);
 
 void delete_rows(duckdb::Connection &con, const table_def &table,
                  const std::string &staging_table_name,

--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -47,8 +47,9 @@ void update_values(duckdb::Connection &con, const table_def &table,
                    const std::string &unmodified_string);
 
 void truncate_table(duckdb::Connection &con, const table_def &table,
-                    const std::string synced_column,
-                    std::chrono::nanoseconds combined_duration);
+                    const std::string &synced_column,
+                    std::chrono::nanoseconds &combined_duration,
+                    const std::string &deleted_column);
 
 void delete_rows(duckdb::Connection &con, const table_def &table,
                  const std::string &staging_table_name,

--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -15,7 +15,7 @@ struct table_def {
   std::string schema_name;
   std::string table_name;
 
-  std::string to_string() const;
+  std::string to_escaped_string() const;
 };
 
 bool schema_exists(duckdb::Connection &con, const std::string &db_name,

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -253,7 +253,11 @@ DestinationSdkImpl::Truncate(::grpc::ServerContext *context,
         get_connection(request->configuration(), db_name);
 
     if (table_exists(*con, table_name)) {
-      truncate_table(*con, table_name);
+      std::chrono::nanoseconds delete_before_ts =
+          std::chrono::seconds(request->utc_delete_before().seconds()) +
+          std::chrono::nanoseconds(request->utc_delete_before().nanos());
+      truncate_table(*con, table_name, request->synced_column(),
+                     delete_before_ts);
     } else {
       mdlog::warning("Table <" + request->table_name() +
                      "> not found in schema <" + request->schema_name() +

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -249,6 +249,13 @@ DestinationSdkImpl::Truncate(::grpc::ServerContext *context,
         find_property(request->configuration(), MD_PROP_DATABASE);
     table_def table_name{db_name, get_schema_name(request),
                          get_table_name(request)};
+    if (request->synced_column().empty()) {
+      throw std::invalid_argument("Synced column is required");
+    }
+    if (request->soft().deleted_column().empty()) {
+      // right now, only soft deletes are supported
+      throw std::invalid_argument("Deleted column is required");
+    }
     std::unique_ptr<duckdb::Connection> con =
         get_connection(request->configuration(), db_name);
 
@@ -257,7 +264,7 @@ DestinationSdkImpl::Truncate(::grpc::ServerContext *context,
           std::chrono::seconds(request->utc_delete_before().seconds()) +
           std::chrono::nanoseconds(request->utc_delete_before().nanos());
       truncate_table(*con, table_name, request->synced_column(),
-                     delete_before_ts);
+                     delete_before_ts, request->soft().deleted_column());
     } else {
       mdlog::warning("Table <" + request->table_name() +
                      "> not found in schema <" + request->schema_name() +

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -8,7 +8,7 @@ using duckdb::KeywordHelper;
 
 // Utility
 
-std::string table_def::to_string() const {
+std::string table_def::to_escaped_string() const {
   std::ostringstream out;
   out << KeywordHelper::WriteQuoted(db_name, '"') << "."
       << KeywordHelper::WriteQuoted(schema_name, '"') << "."
@@ -65,7 +65,7 @@ bool table_exists(duckdb::Connection &con, const table_def &table) {
 
   if (result->HasError()) {
     throw std::runtime_error("Could not find whether table <" +
-                             table.to_string() +
+                             table.to_escaped_string() +
                              "> exists: " + result->GetError());
   }
   auto materialized_result = duckdb::unique_ptr_cast<
@@ -83,7 +83,7 @@ void create_schema(duckdb::Connection &con, const std::string &db_name,
 void create_table(duckdb::Connection &con, const table_def &table,
                   const std::vector<const column_def *> &columns_pk,
                   const std::vector<column_def> &all_columns) {
-  const std::string absolute_table_name = table.to_string();
+  const std::string absolute_table_name = table.to_escaped_string();
   std::ostringstream ddl;
   ddl << "CREATE OR REPLACE TABLE " << absolute_table_name << " (";
 
@@ -129,7 +129,7 @@ std::vector<column_def> describe_table(duckdb::Connection &con,
   auto result = statement->Execute(params, false);
 
   if (result->HasError()) {
-    throw std::runtime_error("Could not describe table <" + table.to_string() +
+    throw std::runtime_error("Could not describe table <" + table.to_escaped_string() +
                              ">:" + result->GetError());
   }
   auto materialized_result = duckdb::unique_ptr_cast<
@@ -148,7 +148,7 @@ std::vector<column_def> describe_table(duckdb::Connection &con,
 void alter_table(duckdb::Connection &con, const table_def &table,
                  const std::vector<column_def> &columns) {
 
-  auto absolute_table_name = table.to_string();
+  auto absolute_table_name = table.to_escaped_string();
   std::set<std::string> alter_types;
   std::set<std::string> added_columns;
   std::set<std::string> deleted_columns;
@@ -233,7 +233,7 @@ void upsert(duckdb::Connection &con, const table_def &table,
             const std::string &staging_table_name,
             std::vector<const column_def *> &columns_pk,
             std::vector<const column_def *> &columns_regular) {
-  const std::string absolute_table_name = table.to_string();
+  const std::string absolute_table_name = table.to_escaped_string();
   std::ostringstream sql;
   sql << "INSERT INTO " << absolute_table_name << " SELECT * FROM "
       << staging_table_name;
@@ -264,7 +264,7 @@ void update_values(duckdb::Connection &con, const table_def &table,
                    const std::string &unmodified_string) {
 
   std::ostringstream sql;
-  auto absolute_table_name = table.to_string();
+  auto absolute_table_name = table.to_escaped_string();
 
   sql << "UPDATE " << absolute_table_name << " SET ";
 
@@ -299,7 +299,7 @@ void delete_rows(duckdb::Connection &con, const table_def &table,
                  const std::string &staging_table_name,
                  std::vector<const column_def *> &columns_pk) {
 
-  const std::string absolute_table_name = table.to_string();
+  const std::string absolute_table_name = table.to_escaped_string();
   std::ostringstream sql;
   sql << "DELETE FROM " + absolute_table_name << " USING " << staging_table_name
       << " WHERE ";
@@ -323,7 +323,7 @@ void truncate_table(duckdb::Connection &con, const table_def &table,
                     const std::string &synced_column,
                     std::chrono::nanoseconds &cutoff_ns,
                     const std::string &deleted_column) {
-  const std::string absolute_table_name = table.to_string();
+  const std::string absolute_table_name = table.to_escaped_string();
   std::ostringstream sql;
 
   sql << "UPDATE " << absolute_table_name << " SET "

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -129,7 +129,8 @@ std::vector<column_def> describe_table(duckdb::Connection &con,
   auto result = statement->Execute(params, false);
 
   if (result->HasError()) {
-    throw std::runtime_error("Could not describe table <" + table.to_escaped_string() +
+    throw std::runtime_error("Could not describe table <" +
+                             table.to_escaped_string() +
                              ">:" + result->GetError());
   }
   auto materialized_result = duckdb::unique_ptr_cast<

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -321,12 +321,14 @@ void delete_rows(duckdb::Connection &con, const table_def &table,
 }
 
 void truncate_table(duckdb::Connection &con, const table_def &table,
-                    const std::string synced_column,
-                    std::chrono::nanoseconds cutoff_ns) {
+                    const std::string &synced_column,
+                    std::chrono::nanoseconds &cutoff_ns,
+                    const std::string &deleted_column) {
   const std::string absolute_table_name = table.to_string();
   std::ostringstream sql;
 
-  sql << "DELETE FROM " << absolute_table_name << " WHERE "
+  sql << "UPDATE " << absolute_table_name << " SET "
+      << KeywordHelper::WriteQuoted(deleted_column, '"') << " = true WHERE "
       << KeywordHelper::WriteQuoted(synced_column, '"')
       << " < make_timestamp(?)";
   auto query = sql.str();

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -37,9 +37,8 @@ void write_joined(
 // TODO: add test for schema or remove the logic if it's unused
 bool schema_exists(duckdb::Connection &con, const std::string &db_name,
                    const std::string &schema_name) {
-  const std::string query =
-      "SELECT schema_name FROM information_schema.schemata "
-      "WHERE catalog_name=? AND schema_name=?";
+  const std::string query = "SELECT schema_name FROM information_schema.schemata "
+                      "WHERE catalog_name=? AND schema_name=?";
   auto statement = con.Prepare(query);
   duckdb::vector<duckdb::Value> params = {duckdb::Value(db_name),
                                           duckdb::Value(schema_name)};
@@ -56,9 +55,8 @@ bool schema_exists(duckdb::Connection &con, const std::string &db_name,
 }
 
 bool table_exists(duckdb::Connection &con, const table_def &table) {
-  const std::string query =
-      "SELECT table_name FROM information_schema.tables WHERE "
-      "table_catalog=? AND table_schema=? AND table_name=?";
+  const std::string query = "SELECT table_name FROM information_schema.tables WHERE "
+                      "table_catalog=? AND table_schema=? AND table_name=?";
   auto statement = con.Prepare(query);
   duckdb::vector<duckdb::Value> params = {duckdb::Value(table.db_name),
                                           duckdb::Value(table.schema_name),

--- a/test/files/books_update.csv
+++ b/test/files/books_update.csv
@@ -1,3 +1,3 @@
 id,title,magic_number,_fivetran_deleted,_fivetran_synced
-3,"unmod-NcK9NIjPUutCsz4mjOQQztbnwnE1sY3",15,false,"2024-01-09T04:30:13.984276065Z"
-2,"The empire strikes back","unmod-NcK9NIjPUutCsz4mjOQQztbnwnE1sY3",false,"2024-01-09T04:30:13.984276065Z"
+3,"unmod-NcK9NIjPUutCsz4mjOQQztbnwnE1sY3",15,false,"2024-02-08T23:59:59.999999999Z"
+2,"The empire strikes back","unmod-NcK9NIjPUutCsz4mjOQQztbnwnE1sY3",false,"2024-02-09T00:00:00.000000000Z"

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -610,7 +610,6 @@ TEST_CASE("Truncate nonexistent table should succeed", "[integration]") {
                                  "<some_schema>; not truncated"));
 }
 
-
 TEST_CASE("Truncate fails if required properties are missing") {
 
   DestinationSdkImpl service;


### PR DESCRIPTION
Two fixes for truncate behavior:
- hard deletes are not supported yet; all truncates have to be soft-delete
- truncate should take into account the column / value for `utc_delete_before` (timestamp prior to which to delete rows).


Fixes #15 
Fixes #9 