### PR TITLE
fix: Fully specify the list of columns to insert

### DIFF
--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -38,8 +38,8 @@ void alter_table(duckdb::Connection &con, const table_def &table,
 
 void upsert(duckdb::Connection &con, const table_def &table,
             const std::string &staging_table_name,
-            std::vector<const column_def *> &columns_pk,
-            std::vector<const column_def *> &columns_regular);
+            const std::vector<const column_def *> &columns_pk,
+            const std::vector<const column_def *> &columns_regular);
 
 void update_values(duckdb::Connection &con, const table_def &table,
                    const std::string &staging_table_name,


### PR DESCRIPTION
The order of columns can change from when the table was originally created.