### PR TITLE
Use the passed-in `null_string` to set true NULL values

### DIFF
--- a/includes/csv_arrow_ingest.hpp
+++ b/includes/csv_arrow_ingest.hpp
@@ -1,10 +1,10 @@
 #include <arrow/csv/api.h>
 
-std::shared_ptr<arrow::Table>
-read_encrypted_csv(const std::string &filename,
-                   const std::string &decryption_key,
-                   std::vector<std::string> &utf8_columns);
+std::shared_ptr<arrow::Table> read_encrypted_csv(
+    const std::string &filename, const std::string &decryption_key,
+    std::vector<std::string> &utf8_columns, const std::string &null_value);
 
 std::shared_ptr<arrow::Table>
 read_unencrypted_csv(const std::string &filename,
-                     std::vector<std::string> &utf8_columns);
+                     std::vector<std::string> &utf8_columns,
+                     const std::string &null_value);

--- a/test/files/books_update.csv
+++ b/test/files/books_update.csv
@@ -1,3 +1,4 @@
 id,title,magic_number,_fivetran_deleted,_fivetran_synced
 3,"unmod-NcK9NIjPUutCsz4mjOQQztbnwnE1sY3",15,false,"2024-02-08T23:59:59.999999999Z"
 2,"The empire strikes back","unmod-NcK9NIjPUutCsz4mjOQQztbnwnE1sY3",false,"2024-02-09T00:00:00.000000000Z"
+99,"magic-nullvalue",99,false,"2024-01-09T04:10:19.156057706Z"

--- a/test/files/books_upsert.csv
+++ b/test/files/books_upsert.csv
@@ -1,3 +1,4 @@
 id,title,magic_number,_fivetran_deleted,_fivetran_synced
 3,"The Hobbit",14,false,"2024-01-09T04:10:19.156057706Z"
 2,"The Two Towers",1,false,"2024-01-09T04:10:19.156057706Z"
+99,"null","magic-nullvalue",false,"2024-01-09T04:10:19.156057706Z"

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -344,6 +344,7 @@ TEST_CASE("WriteBatch", "[integration][current]") {
     (*request.mutable_configuration())["motherduck_token"] = token;
     (*request.mutable_configuration())["motherduck_database"] = "fivetran_test";
     define_test_table(request, table_name);
+    request.mutable_csv()->set_null_string("magic-nullvalue");
     const std::string filename = "books_upsert.csv";
     const std::string filepath = TEST_RESOURCES_DIR + filename;
 
@@ -360,7 +361,7 @@ TEST_CASE("WriteBatch", "[integration][current]") {
                           " ORDER BY id");
     REQUIRE_NO_FAIL(res);
 
-    REQUIRE(res->RowCount() == 3);
+    REQUIRE(res->RowCount() == 4);
     REQUIRE(res->GetValue(0, 0) == 1);
     REQUIRE(res->GetValue(1, 0) == "The Hitchhiker's Guide to the Galaxy");
     REQUIRE(res->GetValue(2, 0) == 42);
@@ -373,6 +374,13 @@ TEST_CASE("WriteBatch", "[integration][current]") {
     REQUIRE(res->GetValue(0, 2) == 3);
     REQUIRE(res->GetValue(1, 2) == "The Hobbit");
     REQUIRE(res->GetValue(2, 2) == 14);
+
+    // new row with null value
+    REQUIRE(res->GetValue(0, 3) == 99);
+    REQUIRE(res->GetValue(1, 3).IsNull() ==
+            false); // a string with text "null" should not be null
+    REQUIRE(res->GetValue(1, 3) == "null");
+    REQUIRE(res->GetValue(2, 3).IsNull() == true);
   }
 
   {
@@ -396,7 +404,7 @@ TEST_CASE("WriteBatch", "[integration][current]") {
     auto res = con->Query("SELECT id, title, magic_number FROM " + table_name +
                           " ORDER BY id");
     REQUIRE_NO_FAIL(res);
-    REQUIRE(res->RowCount() == 2);
+    REQUIRE(res->RowCount() == 3);
 
     // row 1 got deleted
     REQUIRE(res->GetValue(0, 0) == 2);
@@ -406,6 +414,10 @@ TEST_CASE("WriteBatch", "[integration][current]") {
     REQUIRE(res->GetValue(0, 1) == 3);
     REQUIRE(res->GetValue(1, 1) == "The Hobbit");
     REQUIRE(res->GetValue(2, 1) == 14);
+
+    REQUIRE(res->GetValue(0, 2) == 99);
+    REQUIRE(res->GetValue(1, 2) == "null");
+    REQUIRE(res->GetValue(2, 2).IsNull() == true);
   }
 
   {
@@ -415,6 +427,7 @@ TEST_CASE("WriteBatch", "[integration][current]") {
     (*request.mutable_configuration())["motherduck_database"] = "fivetran_test";
     request.mutable_csv()->set_unmodified_string(
         "unmod-NcK9NIjPUutCsz4mjOQQztbnwnE1sY3");
+    request.mutable_csv()->set_null_string("magic-nullvalue");
     define_test_table(request, table_name);
     const std::string filename = "books_update.csv";
     const std::string filepath = TEST_RESOURCES_DIR + filename;
@@ -431,7 +444,7 @@ TEST_CASE("WriteBatch", "[integration][current]") {
     auto res = con->Query("SELECT id, title, magic_number FROM " + table_name +
                           " ORDER BY id");
     REQUIRE_NO_FAIL(res);
-    REQUIRE(res->RowCount() == 2);
+    REQUIRE(res->RowCount() == 3);
 
     REQUIRE(res->GetValue(0, 0) == 2);
     REQUIRE(res->GetValue(1, 0) == "The empire strikes back");
@@ -440,6 +453,11 @@ TEST_CASE("WriteBatch", "[integration][current]") {
     REQUIRE(res->GetValue(0, 1) == 3);
     REQUIRE(res->GetValue(1, 1) == "The Hobbit");
     REQUIRE(res->GetValue(2, 1) == 15); // updated value
+
+    REQUIRE(res->GetValue(0, 2) == 99);
+    REQUIRE(res->GetValue(1, 2).IsNull() == true);
+    REQUIRE(res->GetValue(2, 2).IsNull() == false);
+    REQUIRE(res->GetValue(2, 2) == 99);
   }
 
   {
@@ -477,7 +495,7 @@ TEST_CASE("WriteBatch", "[integration][current]") {
     auto res = con->Query("SELECT title, id, magic_number FROM " + table_name +
                           " ORDER BY id");
     REQUIRE_NO_FAIL(res);
-    REQUIRE(res->RowCount() == 2);
+    REQUIRE(res->RowCount() == 3);
   }
 
   {
@@ -508,7 +526,7 @@ TEST_CASE("WriteBatch", "[integration][current]") {
     auto res = con->Query("SELECT title, id, magic_number FROM " + table_name +
                           " ORDER BY id");
     REQUIRE_NO_FAIL(res);
-    REQUIRE(res->RowCount() == 2);
+    REQUIRE(res->RowCount() == 3);
   }
 
   {


### PR DESCRIPTION
I got lucky here that Arrow just had this functionality built-in. It also had 17 (!) values treated as nulls, so I cleared the vector before adding the One True Null Value.

Fixes #21 