### PR TITLE
chore: Enable ASAN/LSAN/UBSAN checks for code quality

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -26,10 +26,10 @@ jobs:
       - name: build the connector
         run: |
           make get_fivetran_protos get_duckdb
-          make build_connector
+          make build_connector_debug
 
       - name: run tests
         env:
           motherduck_token: ${{ secrets.CI_TESTING_TOKEN }}
         run: |
-          ./build/Release/integration_tests
+          ASAN_OPTIONS=alloc_dealloc_mismatch=0  LSAN_OPTIONS=suppressions=lsan-suppressions.supp  ./build/Debug/integration_tests

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -32,4 +32,4 @@ jobs:
         env:
           motherduck_token: ${{ secrets.CI_TESTING_TOKEN }}
         run: |
-          ASAN_OPTIONS=alloc_dealloc_mismatch=0  LSAN_OPTIONS=suppressions=lsan-suppressions.supp  ./build/Debug/integration_tests
+          ASAN_OPTIONS=alloc_dealloc_mismatch=0:fast_unwind_on_malloc=0  LSAN_OPTIONS=suppressions=lsan-suppressions.supp  ./build/Debug/integration_tests

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,6 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: is there clang
+        run: |
+          clang --version
+          echo "cpp = " $CPP
+          $CPP --version
+
       - uses: actions/cache@v3
         id: cache-deps
         with:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -6,13 +6,22 @@ on:
     branches: [main]
 
 jobs:
+
   build_and_test:
     name: Build and test the connector
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
+      - name: install clang-16
+        run: |
+          RUN apt update && apt install -y clang-16
+
       - name: is there clang
+        env:
+          CC=clang-16
+          CXX=clang++-16
+          CPP=clang-cpp-16
         run: |
           clang --version
           echo "cpp = " $CPP

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: install clang-16
         run: |
-          RUN apt update && apt install -y clang-16
+          apt update && apt install -y clang-16
 
       - name: is there clang
         env:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,9 +19,9 @@ jobs:
 
       - name: is there clang
         env:
-          CC=clang-16
-          CXX=clang++-16
-          CPP=clang-cpp-16
+          CC: clang-16
+          CXX: clang++-16
+          CPP: clang-cpp-16
         run: |
           clang --version
           echo "cpp = " $CPP

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: install clang-16
         run: |
-          apt update && apt install -y clang-16
+          sudo apt update && apt install -y clang-16
 
       - name: is there clang
         env:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,17 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: is there clang
-        env:
-          CC: clang-15
-          CXX: clang++-15
-          CPP: clang-cpp-15
-        run: |
-          clang --version
-          clang-15 --version
-          echo "cpp = " $CPP
-          $CPP --version
-
       - uses: actions/cache@v3
         id: cache-deps
         with:
@@ -32,10 +21,18 @@ jobs:
 
       - name: build the dependencies
         if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
+        env:
+          CC: clang-15
+          CXX: clang++-15
+          CPP: clang-cpp-15
         run: |
           make build_openssl_native build_grpc build_arrow build_test_dependencies
 
       - name: build the connector
+        env:
+          CC: clang-15
+          CXX: clang++-15
+          CPP: clang-cpp-15
         run: |
           make get_fivetran_protos get_duckdb
           make build_connector_debug

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,17 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: install clang-16
-        run: |
-          sudo apt update && apt install -y clang-16
-
       - name: is there clang
         env:
-          CC: clang-16
-          CXX: clang++-16
-          CPP: clang-cpp-16
+          CC: clang-15
+          CXX: clang++-15
+          CPP: clang-cpp-15
         run: |
           clang --version
+          clang-15 --version
           echo "cpp = " $CPP
           $CPP --version
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(MotherDuckFivetranDestination C CXX)
 # Debug Asan/Ubsan
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT DISABLE_SANITIZER)
   if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize-blacklist=${CMAKE_CURRENT_LIST_DIR}/sanitizer-disallowed-entries.txt")
     set(ENABLE_UBSAN TRUE)
   else()
     set(ENABLE_UBSAN FALSE)
@@ -20,7 +21,6 @@ endif()
 
 message("-- ENABLE_SANITIZER=${ENABLE_SANITIZER}")
 message("-- ENABLE_UBSAN=${ENABLE_UBSAN}")
-
 
 # Proto generation
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,29 @@
 cmake_minimum_required(VERSION 3.8)
 project(MotherDuckFivetranDestination C CXX)
 
+
+# Debug Asan/Ubsan
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT DISABLE_SANITIZER)
+  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$")
+    set(ENABLE_UBSAN TRUE)
+  else()
+    set(ENABLE_UBSAN FALSE)
+  endif()
+
+  add_compile_options("-fsanitize=address,undefined")
+  add_link_options("-fsanitize=address,undefined")
+  set(ENABLE_SANITIZER TRUE)
+else()
+  set(ENABLE_SANITIZER FALSE)
+  set(ENABLE_UBSAN FALSE)
+endif()
+
+message("-- ENABLE_SANITIZER=${ENABLE_SANITIZER}")
+message("-- ENABLE_UBSAN=${ENABLE_UBSAN}")
+
+
+# Proto generation
+
 set(TARGET_ROOT ${PROJECT_SOURCE_DIR}/gen)
 include(./proto_helper.cmake)
 

--- a/README.md
+++ b/README.md
@@ -50,5 +50,3 @@ To upgrade, change `DUCKDB_VERSION` in [Makefile](Makefile) and re-run `make get
 
 ## TODO
 - support GZIP compression
-- implement truncate-before (utc_delete_before) and synced_column = 4;
-- implement soft delete?

--- a/lsan-suppressions.supp
+++ b/lsan-suppressions.supp
@@ -1,4 +1,4 @@
 # https://github.com/MotherDuck-Open-Source/motherduck-fivetran-connector/issues/33
 leak:arrow::internal::StaticVectorImpl
-duckdb::ArrowTableFunction::ArrowScanBind
+leak:duckdb::ArrowTableFunction::ArrowScanBind
 leak:duckdb::GZipFileSystem

--- a/lsan-suppressions.supp
+++ b/lsan-suppressions.supp
@@ -1,4 +1,5 @@
 # https://github.com/MotherDuck-Open-Source/motherduck-fivetran-connector/issues/33
 leak:arrow::internal::StaticVectorImpl
 leak:duckdb::ArrowTableFunction::ArrowScanBind
+leak:duckdb_arrow_scan
 leak:duckdb::GZipFileSystem

--- a/lsan-suppressions.supp
+++ b/lsan-suppressions.supp
@@ -1,0 +1,2 @@
+# https://github.com/MotherDuck-Open-Source/motherduck-fivetran-connector/issues/33
+leak:arrow::internal::StaticVectorImpl

--- a/lsan-suppressions.supp
+++ b/lsan-suppressions.supp
@@ -1,5 +1,2 @@
 # https://github.com/MotherDuck-Open-Source/motherduck-fivetran-connector/issues/33
 leak:arrow::internal::StaticVectorImpl
-leak:duckdb::ArrowTableFunction::ArrowScanBind
-leak:duckdb_arrow_scan
-leak:duckdb::GZipFileSystem

--- a/lsan-suppressions.supp
+++ b/lsan-suppressions.supp
@@ -1,3 +1,4 @@
 # https://github.com/MotherDuck-Open-Source/motherduck-fivetran-connector/issues/33
 leak:arrow::internal::StaticVectorImpl
+duckdb::ArrowTableFunction::ArrowScanBind
 leak:duckdb::GZipFileSystem

--- a/lsan-suppressions.supp
+++ b/lsan-suppressions.supp
@@ -1,2 +1,3 @@
 # https://github.com/MotherDuck-Open-Source/motherduck-fivetran-connector/issues/33
 leak:arrow::internal::StaticVectorImpl
+leak:duckdb::GZipFileSystem

--- a/sanitizer-disallowed-entries.txt
+++ b/sanitizer-disallowed-entries.txt
@@ -1,0 +1,4 @@
+# cf. https://clang.llvm.org/docs/SanitizerSpecialCaseList.html
+# nothing excluded for now
+#src:*
+#fun:*

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -37,19 +37,18 @@ bool IS_FAIL(const grpc::Status &status, const std::string &expected_error) {
 
 TEST_CASE("ConfigurationForm", "[integration]") {
   DestinationSdkImpl service;
+  ::fivetran_sdk::ConfigurationFormRequest request;
+  ::fivetran_sdk::ConfigurationFormResponse response;
 
-  auto request = ::fivetran_sdk::ConfigurationFormRequest().New();
-  auto response = ::fivetran_sdk::ConfigurationFormResponse().New();
-
-  auto status = service.ConfigurationForm(nullptr, request, response);
+  auto status = service.ConfigurationForm(nullptr, &request, &response);
   REQUIRE_NO_FAIL(status);
 
-  REQUIRE(response->fields_size() == 2);
-  REQUIRE(response->fields(0).name() == "motherduck_token");
-  REQUIRE(response->fields(1).name() == "motherduck_database");
-  REQUIRE(response->tests_size() == 1);
-  REQUIRE(response->tests(0).name() == CONFIG_TEST_NAME_AUTHENTICATE);
-  REQUIRE(response->tests(0).label() == "Test Authentication");
+  REQUIRE(response.fields_size() == 2);
+  REQUIRE(response.fields(0).name() == "motherduck_token");
+  REQUIRE(response.fields(1).name() == "motherduck_database");
+  REQUIRE(response.tests_size() == 1);
+  REQUIRE(response.tests(0).name() == CONFIG_TEST_NAME_AUTHENTICATE);
+  REQUIRE(response.tests(0).label() == "Test Authentication");
 }
 
 TEST_CASE("DescribeTable fails when database missing", "[integration]") {
@@ -301,7 +300,7 @@ std::unique_ptr<duckdb::Connection> get_test_connection(char *token) {
   return std::make_unique<duckdb::Connection>(db);
 }
 
-TEST_CASE("WriteBatch", "[integration][current]") {
+TEST_CASE("WriteBatch", "[integration][write-batch]") {
   DestinationSdkImpl service;
 
   // Schema will be main
@@ -581,7 +580,7 @@ TEST_CASE("WriteBatch", "[integration][current]") {
   }
 }
 
-TEST_CASE("Table with multiple primary keys", "[integration]") {
+TEST_CASE("Table with multiple primary keys", "[integration][write-batch]") {
   DestinationSdkImpl service;
 
   const std::string table_name =


### PR DESCRIPTION
The compile-time sanitize-blacklist is not really used for anything right now; the codebase in this repo is clean.

There are 2 known issues:
* #33 -- a small Arrow object is leaked when DuckDB maps the Arrow memory structure as a view. It can get removed when upgrading to 0.10.x.
* md extension has a malloc/delete mismatch in one place. This will go away automatically once fixed upstream.

 