### PR TITLE
Check the file is accessible before trying to read it

### DIFF
--- a/lsan-suppressions.supp
+++ b/lsan-suppressions.supp
@@ -1,3 +1,4 @@
 # https://github.com/MotherDuck-Open-Source/motherduck-fivetran-connector/issues/33
 leak:arrow::internal::StaticVectorImpl
+leak:duckdb::ArrowTableFunction::ArrowScanBind
 leak:duckdb::GZipFileSystem

--- a/lsan-suppressions.supp
+++ b/lsan-suppressions.supp
@@ -1,4 +1,3 @@
 # https://github.com/MotherDuck-Open-Source/motherduck-fivetran-connector/issues/33
 leak:arrow::internal::StaticVectorImpl
-leak:duckdb::ArrowTableFunction::ArrowScanBind
 leak:duckdb::GZipFileSystem

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -86,13 +86,13 @@ get_encryption_key(const std::string &filename,
   return encryption_key_it->second;
 }
 
-void validate_file(const std::string &filename) {
-  std::ifstream fs(filename.c_str());
+void validate_file(const std::string &file_path) {
+  std::ifstream fs(file_path.c_str());
   if (fs.good()) {
     fs.close();
     return;
   }
-  throw std::invalid_argument("File <" + filename +
+  throw std::invalid_argument("File <" + file_path +
                               "> is missing or inaccessible");
 }
 

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -1,3 +1,4 @@
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -85,12 +86,23 @@ get_encryption_key(const std::string &filename,
   return encryption_key_it->second;
 }
 
+void validate_file(const std::string &filename) {
+  std::ifstream fs(filename.c_str());
+  if (fs.good()) {
+    fs.close();
+    return;
+  }
+  throw std::invalid_argument("File <" + filename +
+                              "> is missing or inaccessible");
+}
+
 void process_file(
     duckdb::Connection &con, const std::string &filename,
     const std::string &decryption_key, std::vector<std::string> &utf8_columns,
     const std::string &null_value,
     const std::function<void(const std::string &view_name)> &process_view) {
 
+  validate_file(filename);
   auto table = decryption_key.empty()
                    ? read_unencrypted_csv(filename, utf8_columns, null_value)
                    : read_encrypted_csv(filename, decryption_key, utf8_columns,

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -823,8 +823,7 @@ TEST_CASE("Truncate fails if synced_column is missing") {
   REQUIRE_FAIL(status, "Synced column is required");
 }
 
-TEST_CASE("reading inaccessible or nonexistent files fails with obvious error "
-          "message") {
+TEST_CASE("reading inaccessible or nonexistent files fails") {
   DestinationSdkImpl service;
 
   const std::string bad_file_name = TEST_RESOURCES_DIR + "nonexistent.csv";
@@ -843,5 +842,6 @@ TEST_CASE("reading inaccessible or nonexistent files fails with obvious error "
 
   ::fivetran_sdk::WriteBatchResponse response;
   auto status = service.WriteBatch(nullptr, &request, &response);
-  REQUIRE_FAIL(status, "is missing or inaccessible");
+  REQUIRE_FAIL(status,
+               "File <" + bad_file_name + "> is missing or inaccessible");
 }


### PR DESCRIPTION
I really should have fixed it the first time I lost time troubleshooting decryption.
Also makes `IS_FAIL` both more and less flexible -- it now supports substring matching rather than full string, but it also fails if the criterion is not matched.

Fixes #8 