### PR TITLE
Manually recreate a table if any column needs to add/remove constraint

### DIFF
--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -32,7 +32,8 @@ void create_schema(duckdb::Connection &con, const std::string &db_name,
 bool table_exists(duckdb::Connection &con, const table_def &table);
 
 void create_table(duckdb::Connection &con, const table_def &table,
-                  const std::vector<column_def> &all_columns);
+                  const std::vector<column_def> &all_columns,
+                  const std::set<std::string> &columns_with_default_value);
 
 std::vector<column_def> describe_table(duckdb::Connection &con,
                                        const table_def &table);

--- a/includes/sql_generator.hpp
+++ b/includes/sql_generator.hpp
@@ -18,6 +18,11 @@ struct table_def {
   std::string to_escaped_string() const;
 };
 
+void find_primary_keys(
+    const std::vector<column_def> &cols,
+    std::vector<const column_def *> &columns_pk,
+    std::vector<const column_def *> *columns_regular = nullptr);
+
 bool schema_exists(duckdb::Connection &con, const std::string &db_name,
                    const std::string &schema_name);
 
@@ -27,7 +32,6 @@ void create_schema(duckdb::Connection &con, const std::string &db_name,
 bool table_exists(duckdb::Connection &con, const table_def &table);
 
 void create_table(duckdb::Connection &con, const table_def &table,
-                  const std::vector<const column_def *> &columns_pk,
                   const std::vector<column_def> &all_columns);
 
 std::vector<column_def> describe_table(duckdb::Connection &con,

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -134,19 +134,6 @@ void process_file(
   arrow_array_stream.release(&arrow_array_stream);
 }
 
-void find_primary_keys(
-    const std::vector<column_def> &cols,
-    std::vector<const column_def *> &columns_pk,
-    std::vector<const column_def *> *columns_regular = nullptr) {
-  for (auto &col : cols) {
-    if (col.primary_key) {
-      columns_pk.push_back(&col);
-    } else if (columns_regular != nullptr) {
-      columns_regular->push_back(&col);
-    }
-  }
-}
-
 grpc::Status DestinationSdkImpl::ConfigurationForm(
     ::grpc::ServerContext *context,
     const ::fivetran_sdk::ConfigurationFormRequest *request,
@@ -259,10 +246,8 @@ grpc::Status DestinationSdkImpl::CreateTable(
       create_schema(*con, db_name, schema_name);
     }
 
-    std::vector<const column_def *> columns_pk;
     const auto cols = get_duckdb_columns(request->table().columns());
-    find_primary_keys(cols, columns_pk);
-    create_table(*con, table, columns_pk, cols);
+    create_table(*con, table, cols);
     response->set_success(true);
   } catch (const std::exception &e) {
     mdlog::severe("CreateTable endpoint failed for schema <" +

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -29,7 +29,9 @@ int find_optional_property(
     const std::string &property_name, int default_value,
     const std::function<int(const std::string &)> &parse) {
   auto token_it = config.find(property_name);
-  return token_it == config.end() || token_it->second.empty() ? default_value : parse(token_it->second);
+  return token_it == config.end() || token_it->second.empty()
+             ? default_value
+             : parse(token_it->second);
 }
 
 template <typename T> std::string get_schema_name(const T *request) {

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -247,7 +247,7 @@ grpc::Status DestinationSdkImpl::CreateTable(
     }
 
     const auto cols = get_duckdb_columns(request->table().columns());
-    create_table(*con, table, cols);
+    create_table(*con, table, cols, {});
     response->set_success(true);
   } catch (const std::exception &e) {
     mdlog::severe("CreateTable endpoint failed for schema <" +

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -348,12 +348,12 @@ void alter_table(duckdb::Connection &con, const table_def &table,
       if (col.primary_key) {
         recreate_table = true;
       }
-    } else if (new_col_it->second.type != col.type) {
-      alter_types.emplace(col.name);
     } else if (new_col_it->second.primary_key != col.primary_key) {
       mdlog::info("Altering primary key requested for column <" +
                   new_col_it->second.name + ">");
       recreate_table = true;
+    } else if (new_col_it->second.type != col.type) {
+      alter_types.emplace(col.name);
     }
   }
 

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -237,9 +237,9 @@ TEST_CASE("Test endpoint fails when token is bad",
   auto status = service.Test(nullptr, &request, &response);
   REQUIRE_NO_FAIL(status);
   CHECK_THAT(status.error_message(),
-             Catch::Matchers::ContainsSubstring("UNAUTHENTICATED"));
+             Catch::Matchers::ContainsSubstring("not authenticated"));
   CHECK_THAT(status.error_message(),
-             Catch::Matchers::ContainsSubstring("UNAUTHENTICATED"));
+             Catch::Matchers::ContainsSubstring("not authenticated"));
 }
 
 TEST_CASE(

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -1209,14 +1209,16 @@ TEST_CASE("Test all types with create and describe table") {
 }
 
 template <typename T>
-void add_config(T &request, const std::string &token, const std::string &database, const std::string &table) {
+void add_config(T &request, const std::string &token,
+                const std::string &database, const std::string &table) {
   (*request.mutable_configuration())["motherduck_token"] = token;
   (*request.mutable_configuration())["motherduck_database"] = database;
   request.mutable_table()->set_name(table);
 }
 
 template <typename T>
-void add_col(T &request, const std::string &name, ::fivetran_sdk::DataType type, bool is_primary_key) {
+void add_col(T &request, const std::string &name, ::fivetran_sdk::DataType type,
+             bool is_primary_key) {
   auto col = request.mutable_table()->add_columns();
   col->set_name(name);
   col->set_type(type);
@@ -1237,8 +1239,8 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
     // Create Table
     ::fivetran_sdk::CreateTableRequest request;
     add_config(request, token, TEST_DATABASE_NAME, table_name);
-    add_col(request, "id",::fivetran_sdk::DataType::STRING, true);
-    add_col(request, "name",::fivetran_sdk::DataType::STRING, false);
+    add_col(request, "id", ::fivetran_sdk::DataType::STRING, true);
+    add_col(request, "name", ::fivetran_sdk::DataType::STRING, false);
 
     ::fivetran_sdk::CreateTableResponse response;
     auto status = service.CreateTable(nullptr, &request, &response);
@@ -1485,7 +1487,7 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
 
     REQUIRE(response.table().columns(2).name() == "id_int");
     REQUIRE(response.table().columns(2).type() ==
-            ::fivetran_sdk::DataType::LONG);  // this type got updated
+            ::fivetran_sdk::DataType::LONG); // this type got updated
     REQUIRE_FALSE(response.table().columns(2).primary_key());
 
     REQUIRE(response.table().columns(3).name() == "id_varchar");
@@ -1500,7 +1502,7 @@ TEST_CASE("AlterTable with constraints", "[integration]") {
 
     REQUIRE(response.table().columns(5).name() == "id_float");
     REQUIRE(response.table().columns(5).type() ==
-            ::fivetran_sdk::DataType::FLOAT);  
+            ::fivetran_sdk::DataType::FLOAT);
     REQUIRE(response.table().columns(5).primary_key());
   }
 


### PR DESCRIPTION
DuckDB does not yet support ALTER TABLE with any constraints modifications (even DROP COLUMN fails if the column has a primary key).

This PR works around the limitation by renaming the original table, creating a new table with the correct structure, and copying all the old data from columns that were present in both the old table and the new table structure into it.

Fixes #44.
Fixes #2 in a better way (by making it work rather than throwing exception).
Fixes ECO-149