### PR TITLE
Check for optional field presence before using them

### DIFF
--- a/includes/motherduck_destination_server.hpp
+++ b/includes/motherduck_destination_server.hpp
@@ -15,6 +15,10 @@ static constexpr const char *const CONFIG_TEST_NAME_AUTHENTICATE =
 static constexpr const char *const CONFIG_TEST_NAME_CSV_BLOCK_SIZE =
     "test_csv_block_size";
 
+static const int DUCKDB_DEFAULT_PRECISION = 18;
+
+static const int DUCKDB_DEFAULT_SCALE = 3;
+
 class DestinationSdkImpl final : public fivetran_sdk::Destination::Service {
 public:
   DestinationSdkImpl() = default;

--- a/includes/motherduck_destination_server.hpp
+++ b/includes/motherduck_destination_server.hpp
@@ -15,9 +15,9 @@ static constexpr const char *const CONFIG_TEST_NAME_AUTHENTICATE =
 static constexpr const char *const CONFIG_TEST_NAME_CSV_BLOCK_SIZE =
     "test_csv_block_size";
 
-static const int DUCKDB_DEFAULT_PRECISION = 18;
+static constexpr const int DUCKDB_DEFAULT_PRECISION = 18;
 
-static const int DUCKDB_DEFAULT_SCALE = 3;
+static constexpr const int DUCKDB_DEFAULT_SCALE = 3;
 
 class DestinationSdkImpl final : public fivetran_sdk::Destination::Service {
 public:

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -62,9 +62,10 @@ std::vector<column_def> get_duckdb_columns(
                                   DataType_Name(col.type()) + "> for column <" +
                                   col.name() + "> to a DuckDB type");
     }
+    auto precision = col.has_decimal() ? col.decimal().precision() : 18;
+    auto scale = col.has_decimal() ? col.decimal().scale() : 3;
     duckdb_columns.push_back(column_def{col.name(), ddbtype, col.primary_key(),
-                                        col.decimal().precision(),
-                                        col.decimal().scale()});
+        precision, scale});
   }
   return duckdb_columns;
 }
@@ -310,8 +311,9 @@ DestinationSdkImpl::Truncate(::grpc::ServerContext *context,
       std::chrono::nanoseconds delete_before_ts =
           std::chrono::seconds(request->utc_delete_before().seconds()) +
           std::chrono::nanoseconds(request->utc_delete_before().nanos());
+          const std::string deleted_column = request->has_soft() ? request->soft().deleted_column() : "";
       truncate_table(*con, table_name, request->synced_column(),
-                     delete_before_ts, request->soft().deleted_column());
+                     delete_before_ts, deleted_column);
     } else {
       mdlog::warning("Table <" + request->table_name() +
                      "> not found in schema <" + request->schema_name() +

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -62,8 +62,8 @@ std::vector<column_def> get_duckdb_columns(
                                   DataType_Name(col.type()) + "> for column <" +
                                   col.name() + "> to a DuckDB type");
     }
-    auto precision = col.has_decimal() ? col.decimal().precision() : 18;
-    auto scale = col.has_decimal() ? col.decimal().scale() : 3;
+    auto precision = col.has_decimal() ? col.decimal().precision() : DUCKDB_DEFAULT_PRECISION;
+    auto scale = col.has_decimal() ? col.decimal().scale() : DUCKDB_DEFAULT_SCALE;
     duckdb_columns.push_back(column_def{col.name(), ddbtype, col.primary_key(),
         precision, scale});
   }


### PR DESCRIPTION
I actually had tests for the hard-delete scenario, but the thing with invalid memory access is that it's invalid in different ways...

This is likely what's causing the segfault for fivetran_log and github connectors.