### PR TITLE
More accurate bind errors

### DIFF
--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -62,10 +62,12 @@ std::vector<column_def> get_duckdb_columns(
                                   DataType_Name(col.type()) + "> for column <" +
                                   col.name() + "> to a DuckDB type");
     }
-    auto precision = col.has_decimal() ? col.decimal().precision() : DUCKDB_DEFAULT_PRECISION;
-    auto scale = col.has_decimal() ? col.decimal().scale() : DUCKDB_DEFAULT_SCALE;
-    duckdb_columns.push_back(column_def{col.name(), ddbtype, col.primary_key(),
-        precision, scale});
+    auto precision = col.has_decimal() ? col.decimal().precision()
+                                       : DUCKDB_DEFAULT_PRECISION;
+    auto scale =
+        col.has_decimal() ? col.decimal().scale() : DUCKDB_DEFAULT_SCALE;
+    duckdb_columns.push_back(
+        column_def{col.name(), ddbtype, col.primary_key(), precision, scale});
   }
   return duckdb_columns;
 }
@@ -311,7 +313,8 @@ DestinationSdkImpl::Truncate(::grpc::ServerContext *context,
       std::chrono::nanoseconds delete_before_ts =
           std::chrono::seconds(request->utc_delete_before().seconds()) +
           std::chrono::nanoseconds(request->utc_delete_before().nanos());
-          const std::string deleted_column = request->has_soft() ? request->soft().deleted_column() : "";
+      const std::string deleted_column =
+          request->has_soft() ? request->soft().deleted_column() : "";
       truncate_table(*con, table_name, request->synced_column(),
                      delete_before_ts, deleted_column);
     } else {


### PR DESCRIPTION
Right now, if the query is invalid, the error message is unhelpful -- "Attempting to execute an unsuccessfully prepared statement!". This PR surfaces bind errors instead of trying to run the invalid query.

I also threw in a couple of extra log lines in Truncate endpoint because that's the best guess so far about what's segfaulting for some but not all connectors in prod.