### PR TITLE
Skip the optional decimal field if type is not decimal; add logging

### DIFF
--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -186,7 +186,6 @@ std::vector<column_def> describe_table(duckdb::Connection &con,
   // TBD is_identity is never set, used is_nullable=no temporarily but really
   // should use duckdb_constraints table.
 
-  // TBD scale/precision
   std::vector<column_def> columns;
 
   auto query = "SELECT "
@@ -221,7 +220,7 @@ std::vector<column_def> describe_table(duckdb::Connection &con,
     duckdb::LogicalTypeId column_type =
         static_cast<duckdb::LogicalTypeId>(row.GetValue(1).GetValue<int8_t>());
     column_def col{row.GetValue(0).GetValue<duckdb::string>(), column_type,
-                   row.GetValue(2).GetValue<bool>()};
+                   row.GetValue(2).GetValue<bool>(), 0, 0};
     if (column_type == duckdb::LogicalTypeId::DECIMAL) {
       col.width = row.GetValue(3).GetValue<uint32_t>();
       col.scale = row.GetValue(4).GetValue<uint32_t>();

--- a/test/integration/test_server.cpp
+++ b/test/integration/test_server.cpp
@@ -145,6 +145,7 @@ TEST_CASE("CreateTable, DescribeTable for existing table, AlterTable",
       REQUIRE(response.table().columns(0).name() == "id");
       REQUIRE(response.table().columns(0).type() ==
               ::fivetran_sdk::DataType::STRING);
+      REQUIRE_FALSE(response.table().columns(0).has_decimal());
     }
   }
 
@@ -1164,6 +1165,7 @@ TEST_CASE("Test all types with create and describe table") {
     REQUIRE(response.table().columns(2).name() == "col_decimal");
     REQUIRE(response.table().columns(2).type() ==
             ::fivetran_sdk::DataType::DECIMAL);
+    REQUIRE(response.table().columns(2).has_decimal());
     REQUIRE(response.table().columns(2).decimal().scale() == 11);
     REQUIRE(response.table().columns(2).decimal().precision() == 20);
     REQUIRE_FALSE(response.table().columns(2).primary_key());


### PR DESCRIPTION
The `fivetran_log` connector is experiencing an occasional "UNAVAILABLE: Network closed for unknown reason" error during Describe calls. This kind of error tends to indicate the connector or its container shut down unexpectedly. 
The only place where I can even imagine a process crash is maybe this uninitialized decimal field for a non-decimal column... But I also added more logging to pinpoint what exactly fails.