### PR TITLE
Connect in single attach mode

### DIFF
--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -81,6 +81,7 @@ std::unique_ptr<duckdb::Connection> get_connection(
   config.SetOptionByName(MD_PROP_TOKEN, token);
   config.SetOptionByName("custom_user_agent", "fivetran");
   config.SetOptionByName("old_implicit_casting", true);
+  config.SetOptionByName("motherduck_attach_mode", "single");
 
   duckdb::DuckDB db("md:" + db_name, &config);
   return std::make_unique<duckdb::Connection>(db);


### PR DESCRIPTION
I've detached most of my databases and re-ran the intermittently failing fivetran_log connector and it passed. It could be a coincidence! But connecting in single mode is the right thing to do anyway since Fivetran requests are always scoped to one database.