### PR TITLE
Add a signal handler to print crashes, plus extra logging

### DIFF
--- a/src/motherduck_destination.cpp
+++ b/src/motherduck_destination.cpp
@@ -42,18 +42,7 @@ void download_motherduck_extension() {
 }
 
 void logCrash(int sig) {
-  void *array[512];
-  size_t size = backtrace(array, 512);
-  char **strings = backtrace_symbols(array, size);
-
   std::cerr << "Crash signal " << sig << std::endl;
-  std::cerr << "Stack trace: " << std::endl;
-
-  for (size_t i = 0; i < size; i++) {
-    std::cerr << strings[i] << std::endl;
-  }
-
-  free(strings);
   std::exit(sig);
 }
 

--- a/src/motherduck_destination_server.cpp
+++ b/src/motherduck_destination_server.cpp
@@ -204,10 +204,16 @@ grpc::Status DestinationSdkImpl::DescribeTable(
         find_property(request->configuration(), MD_PROP_DATABASE);
     std::unique_ptr<duckdb::Connection> con =
         get_connection(request->configuration(), db_name);
+    mdlog::info("Endpoint <DescribeTable>: got connection");
     table_def table_name{db_name, get_schema_name(request),
                          get_table_name(request)};
 
+    mdlog::info("Endpoint <DescribeTable>: schema name <" +
+                table_name.schema_name + ">");
+    mdlog::info("Endpoint <DescribeTable>: table name <" +
+                table_name.table_name + ">");
     if (!table_exists(*con, table_name)) {
+      mdlog::info("Endpoint <DescribeTable>: table not found");
       response->set_not_found(true);
       return ::grpc::Status(::grpc::StatusCode::OK, "");
     }

--- a/src/sql_generator.cpp
+++ b/src/sql_generator.cpp
@@ -102,6 +102,7 @@ bool table_exists(duckdb::Connection &con, const table_def &table) {
   const std::string err =
       "Could not find whether table <" + table.to_escaped_string() + "> exists";
   auto statement = con.Prepare(query);
+  mdlog::info("    prepared table_exists query for table " + table.table_name);
   if (statement->HasError()) {
     throw std::runtime_error(err + " (at bind step): " + statement->GetError());
   }
@@ -109,12 +110,15 @@ bool table_exists(duckdb::Connection &con, const table_def &table) {
                                           duckdb::Value(table.schema_name),
                                           duckdb::Value(table.table_name)};
   auto result = statement->Execute(params, false);
+  mdlog::info("    executed table_exists query for table " + table.table_name);
 
   if (result->HasError()) {
     throw std::runtime_error(err + ": " + result->GetError());
   }
   auto materialized_result = duckdb::unique_ptr_cast<
       duckdb::QueryResult, duckdb::MaterializedQueryResult>(std::move(result));
+  mdlog::info("    materialized table_exists results for table " +
+              table.table_name);
   return materialized_result->RowCount() > 0;
 }
 


### PR DESCRIPTION
I induced a crash in describe logic to test the signal handler. It works fine to at least leave stdout information that a crash happened.
The extra logging is not interesting code-wise; it's just to diagnose where the process crashes.